### PR TITLE
refactor backends, s3 buckets

### DIFF
--- a/terraform/aws/backend-configs/example.tfbackend
+++ b/terraform/aws/backend-configs/example.tfbackend
@@ -1,0 +1,3 @@
+bucket = "eoapi-tfstate-v2-ogc"
+key    = "terraform"
+region = "us-east-1"

--- a/terraform/aws/backend-configs/example.tfbackend
+++ b/terraform/aws/backend-configs/example.tfbackend
@@ -1,3 +1,3 @@
-bucket = "eoapi-tfstate-v2-ogc"
+bucket = "eoapi-tfstate-v2-example"
 key    = "terraform"
-region = "us-east-1"
+region = "us-west-2"

--- a/terraform/aws/backend-configs/ogc-dev.tfbackend
+++ b/terraform/aws/backend-configs/ogc-dev.tfbackend
@@ -1,0 +1,3 @@
+bucket = "eoapi-tfstate-v2-ogc"
+key    = "terraform"
+region = "us-east-1"

--- a/terraform/aws/howtoterraform.md
+++ b/terraform/aws/howtoterraform.md
@@ -1,18 +1,40 @@
+### Terraform Installation
 0. cd terraform/aws
-0. install `tfenv` to manage multiple versions: [https://github.com/tfutils/tfenv](https://github.com/tfutils/tfenv)
-0. our `main.tf` file has a `required_version = "1.7.4"` so install that:
 
-  ```bash
-  $ tfenv list
+1. install `tfenv` to manage multiple versions: [https://github.com/tfutils/tfenv](https://github.com/tfutils/tfenv)
+
+2. our `main.tf` file has a `required_version = "1.7.4"` so install that:
+   ```bash
+   $ tfenv list
     1.1.5
     1.1.4
-  ```
+   ```
 
-0. `tfenv install 1.7.4`
-0. `tfenv use 1.7.4`
-0. manually create your TF state bucket name listed in `terraform/aws/main.tf` or choose a new one and change `terraform/aws/main.tf`
-0. `AWS_PROFILE=(profile-name) terraform init`
-0. cp vars/default vars/(your-profile-name)
-0. `AWS_PROFILE=(profile-name) terraform workspace create (name)`
-0. `AWS_PROFILE=(profile-name) terraform plan --var-file=vars/(your-profile-name)`
-0. `AWS_PRFILE=(profile-name) terraform apply --var-file=vars/(your-profile-name)`
+3. `tfenv install 1.7.4`
+
+4. `tfenv use 1.7.4`
+
+###  Terraform Init and Workspaces
+
+0. choose a name for your project that you'll use for the TF `workspace` name, variable filename and backend-config name. 
+for the purposes of the rest of this walkthrough we'll call it `example-dev`  
+
+1. copy the `backend-configs/example.tfbackend` to `backend-cofnigs/example-dev.tfbackend`. this is the file that sets
+up where your terraform state will be used in s3
+
+2. in that file change the `bucket` value to be a unique bucket name. Leave the `key = terraform` as is. Choose a `region` for your bucket
+
+3. create the s3 bucket manually or via `aws-cli` for that region and bucket name
+
+4. initialize terraform and the state: `AWS_PROFILE=(profile-name) terraform init -reconfigure -backend-config backend-configs/example-dev.tfbackend `
+
+5. finally, create a workspace `AWS_PROFILE=(profile-name) terraform workspace create example-dev`
+
+
+### Terraform Plan and Apply
+
+0. cp `vars/example.tfvars` to your `vars/example-dev.tfvars` and make the changes you will need
+
+1. `AWS_PROFILE=(profile-name) terraform plan --var-file=vars/example-dev.tfvars`
+
+3. `AWS_PRFILE=(profile-name) terraform apply --var-file=vars/example-dev.tfvars`

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,10 +1,9 @@
 terraform {
   required_version = ">= 1.7.4"
-  backend "s3" {
-    bucket = "eoapi-tfstate-v2-ogc"
-    key    = "terraform"
-    region = "us-east-1"
-  }
+
+  # you need to pass this on
+  # `terraform init -backend-config=./backend-configs/<name>.tfbackend`
+  backend "s3" {}
 
   required_providers {
     aws = {

--- a/terraform/aws/nodes.tf
+++ b/terraform/aws/nodes.tf
@@ -14,33 +14,6 @@ resource "aws_iam_role" "nodegroup" {
   })
 }
 
-
-resource "aws_s3_bucket" "data_store" {
-  bucket = "ogc-veda-data-store"
-  # default is private
-}
-
-resource "aws_iam_policy" "eks_s3_access" {
-  name   = "EKSS3AccessPolicy"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "s3:*"
-        ]
-        Effect   = "Allow"
-        Resource = "${aws_s3_bucket.data_store.arn}/*"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "s3_access" {
-  role       = aws_iam_role.nodegroup.name
-  policy_arn = aws_iam_policy.eks_s3_access.arn
-}
-
 resource "aws_iam_role_policy_attachment" "node_worker_policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = aws_iam_role.nodegroup.name

--- a/terraform/aws/s3.tf
+++ b/terraform/aws/s3.tf
@@ -4,6 +4,7 @@ resource "aws_s3_bucket" "data_stores" {
 }
 
 resource "aws_iam_policy" "eks_s3_access" {
+  count      = length(var.bucket_names) > 0 ? 1 : 0
   name   = "EKSS3AccessPolicy"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -22,7 +23,12 @@ resource "aws_iam_policy" "eks_s3_access" {
   })
 }
 
+locals {
+  s3_policy_arn = length(var.bucket_names) > 0 ? aws_iam_policy.eks_s3_access[0].arn : ""
+}
+
 resource "aws_iam_role_policy_attachment" "s3_access" {
+  count      = length(var.bucket_names) > 0 ? 1 : 0
   role       = aws_iam_role.nodegroup.name
-  policy_arn = aws_iam_policy.eks_s3_access.arn
+  policy_arn = local.s3_policy_arn
 }

--- a/terraform/aws/s3.tf
+++ b/terraform/aws/s3.tf
@@ -1,0 +1,28 @@
+resource "aws_s3_bucket" "data_stores" {
+  for_each = toset(var.bucket_names)
+  bucket = each.key
+}
+
+resource "aws_iam_policy" "eks_s3_access" {
+  name   = "EKSS3AccessPolicy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:*"
+        ]
+        Effect   = "Allow"
+        Resource = concat(
+          [for bucketname in var.bucket_names : "arn:aws:s3:::${bucketname}"],
+          [for bucketname in var.bucket_names : "arn:aws:s3:::${bucketname}/*"]
+        )
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "s3_access" {
+  role       = aws_iam_role.nodegroup.name
+  policy_arn = aws_iam_policy.eks_s3_access.arn
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -48,6 +48,15 @@ variable "aws_vpc" {
   EOT
 }
 
+variable "bucket_names" {
+  description = <<-EOT
+  list of s3 buckets to create that you might need the nodes to have access to
+  EOT
+  type        = list(string)
+  default     = []
+}
+
+
 variable "instance_type" {
   default     = "t3.large"
   description = <<-EOT

--- a/terraform/aws/vars/example.tfvars
+++ b/terraform/aws/vars/example.tfvars
@@ -1,10 +1,8 @@
 region = "us-west-2"
-
 # name gets suffixed with `-${cluster_version}`
 cluster_name = "eoapi"
-
 cluster_version = "v2"
-
 prometheus_hostname = ""
-
 instance_type = "t3.xlarge"
+enable_efs = false
+bucket_names = ["whatever-name-data-store",]

--- a/terraform/aws/vars/ogc-dev.tfvars
+++ b/terraform/aws/vars/ogc-dev.tfvars
@@ -5,3 +5,4 @@ cluster_version = "dev"
 prometheus_hostname = ""
 instance_type = "t3.xlarge"
 enable_efs = true
+bucket_names = ["ogc-veda-data-store",]


### PR DESCRIPTION
This PR refactors:

*  `terraform.backends` to be as dynamic as possible
*  handles s3 buckets that need to be created separately

It hasn't been applied yet b/c TF wants to destroy and recreate the s3 bucket even thought the name didn't change 🙄 TF plan attached below

```bash


Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy
 <= read (data resources)

Terraform will perform the following actions:

  # data.aws_iam_policy_document.assume_role_with_oidc will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "assume_role_with_oidc" {
      + id            = (known after apply)
      + json          = (known after apply)
      + minified_json = (known after apply)

      + statement {
          + actions = [
              + "sts:AssumeRoleWithWebIdentity",
            ]
          + effect  = "Allow"

          + principals {
              + identifiers = [
                  + "arn:aws:iam::891377311084:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/BA4D8F84AB91B332E54BB11D80012D5E",
                ]
              + type        = "Federated"
            }
        }
    }

  # aws_iam_openid_connect_provider.cluster_oidc will be updated in-place
  ~ resource "aws_iam_openid_connect_provider" "cluster_oidc" {
        id              = "arn:aws:iam::891377311084:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/BA4D8F84AB91B332E54BB11D80012D5E"
        tags            = {}
      ~ thumbprint_list = [
            # (1 unchanged element hidden)
            "06b25927c42a721631c1efd9431e648fa62e1e39",
          - "d9fe0a65fa00cabf61f5120d373a8135e1461f15",
          - "317ff1796cf8e2bcd874cb3e7b9b61469d82313c",
          + "414a2060b738c635cc7fc243e052615592830c53",
          + "3934cf57a95810cf5b7a7ce04dbb323fdb9a41a7",
        ]
        # (4 unchanged attributes hidden)
    }

  # aws_iam_policy.eks_s3_access will be updated in-place
  ~ resource "aws_iam_policy" "eks_s3_access" {
        id               = "arn:aws:iam::891377311084:policy/EKSS3AccessPolicy"
        name             = "EKSS3AccessPolicy"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = "arn:aws:s3:::ogc-veda-data-store/*" -> [
                          + "arn:aws:s3:::ogc-veda-data-store",
                          + "arn:aws:s3:::ogc-veda-data-store/*",
                        ]
                        # (2 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (5 unchanged attributes hidden)
    }

  # aws_iam_role.ebs_provisioner will be updated in-place
  ~ resource "aws_iam_role" "ebs_provisioner" {
      ~ assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRoleWithWebIdentity"
                      - Effect    = "Allow"
                      - Principal = {
                          - Federated = "arn:aws:iam::891377311084:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/BA4D8F84AB91B332E54BB11D80012D5E"
                        }
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        id                    = "ogc-eoapi-dev-eks-ebs-provisioner"
        name                  = "ogc-eoapi-dev-eks-ebs-provisioner"
        tags                  = {}
        # (8 unchanged attributes hidden)
    }

  # aws_iam_role.efs_provisioner[0] will be updated in-place
  ~ resource "aws_iam_role" "efs_provisioner" {
      ~ assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRoleWithWebIdentity"
                      - Effect    = "Allow"
                      - Principal = {
                          - Federated = "arn:aws:iam::891377311084:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/BA4D8F84AB91B332E54BB11D80012D5E"
                        }
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        id                    = "ogc-eoapi-eks-efs-provisioner"
        name                  = "ogc-eoapi-eks-efs-provisioner"
        tags                  = {}
        # (8 unchanged attributes hidden)
    }

  # aws_s3_bucket.data_store will be destroyed
  # (because resource uses count or for_each)
  - resource "aws_s3_bucket" "data_store" {
      - arn                         = "arn:aws:s3:::ogc-veda-data-store" -> null
      - bucket                      = "ogc-veda-data-store" -> null
      - bucket_domain_name          = "ogc-veda-data-store.s3.amazonaws.com" -> null
      - bucket_regional_domain_name = "ogc-veda-data-store.s3.us-west-2.amazonaws.com" -> null
      - force_destroy               = false -> null
      - hosted_zone_id              = "Z3BJ6K6RIION7M" -> null
      - id                          = "ogc-veda-data-store" -> null
      - object_lock_enabled         = false -> null
      - region                      = "us-west-2" -> null
      - request_payer               = "BucketOwner" -> null
      - tags                        = {} -> null
      - tags_all                    = {} -> null

      - grant {
          - id          = "aa95893132264412dd11cabc286ac5fb6cb36595b1178af32cdab8d57696339c" -> null
          - permissions = [
              - "FULL_CONTROL",
            ] -> null
          - type        = "CanonicalUser" -> null
        }

      - server_side_encryption_configuration {
          - rule {
              - bucket_key_enabled = false -> null

              - apply_server_side_encryption_by_default {
                  - sse_algorithm = "AES256" -> null
                }
            }
        }

      - versioning {
          - enabled    = false -> null
          - mfa_delete = false -> null
        }
    }

  # aws_s3_bucket.data_store["ogc-veda-data-store"] will be created
  + resource "aws_s3_bucket" "data_store" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "ogc-veda-data-store"
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)
    }

Plan: 1 to add, 4 to change, 1 to destroy.
```